### PR TITLE
Update dependency between YoutubePlayerBuilder and YoutubePlayer

### DIFF
--- a/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
+++ b/packages/youtube_player_flutter/lib/src/player/youtube_player.dart
@@ -38,11 +38,17 @@ import 'raw_youtube_player.dart';
 ///)
 /// ```
 ///
-class YoutubePlayer extends StatefulWidget {
+
+mixin IYoutubePlayer on Widget {
+  YoutubePlayerController get controller;
+}
+
+class YoutubePlayer extends StatefulWidget with IYoutubePlayer {
   /// Sets [Key] as an identification to underlying web view associated to the player.
   final Key? key;
 
   /// A [YoutubePlayerController] to control the player.
+  @override
   final YoutubePlayerController controller;
 
   /// {@template youtube_player_flutter.width}

--- a/packages/youtube_player_flutter/lib/src/widgets/youtube_player_builder.dart
+++ b/packages/youtube_player_flutter/lib/src/widgets/youtube_player_builder.dart
@@ -6,7 +6,7 @@ import 'package:youtube_player_flutter/youtube_player_flutter.dart';
 /// A wrapper for [YoutubePlayer].
 class YoutubePlayerBuilder extends StatefulWidget {
   /// The actual [YoutubePlayer].
-  final YoutubePlayer player;
+  final IYoutubePlayer player;
 
   /// Builds the widget below this [builder].
   final Widget Function(BuildContext, Widget) builder;

--- a/packages/youtube_player_flutter/lib/youtube_player_flutter.dart
+++ b/packages/youtube_player_flutter/lib/youtube_player_flutter.dart
@@ -3,6 +3,7 @@ library youtube_player_flutter;
 export 'src/enums/playback_rate.dart';
 export 'src/enums/player_state.dart';
 export 'src/enums/thumbnail_quality.dart';
+export 'src/player/raw_youtube_player.dart';
 export 'src/player/youtube_player.dart';
 export 'src/utils/youtube_meta_data.dart';
 export 'src/utils/youtube_player_controller.dart';


### PR DESCRIPTION
Currently, `YoutubePlayerBuilder` is calling directly to `YoutubePlayer`. So we can not add a `CustomYoutubePlayer` to `YoutubePlayerBuilder`.
Replace it, I create a `mixin` `IYoutubePlayer` and extend it. we can implement `CustomYoutubePlayer` based on `IYoutubePlayer` and inject it on `YoutubePlayerBuilder`. 
I also publish `RawYoutubePlayer` to custom players.